### PR TITLE
Remove gpg key if expired and re-add apt source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ duosecurity CHANGELOG
 
 This file is used to list changes made in each version of the duosecurity cookbook.
 
+1.4.1
+----
+- [mattlqx] - Remove expired Duo repo GPG key and re-add.
+
 1.4.0
 ----
 - [mattlqx] - Compatibility for Ubuntu 18.04 Bionic Beaver.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email    'matt@lqx.net'
 license             'MIT'
 description         'Installs/Configures duosecurity two-factor system authentication on Ubuntu/Debian'
 long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version             '1.4.0'
+version             '1.4.1'
 
 source_url 'https://github.com/mattlqx/chef-duosecurity' if respond_to?(:source_url)
 issues_url 'https://github.com/mattlqx/chef-duosecurity/issues' if respond_to?(:issues_url)


### PR DESCRIPTION
Older hosts may have installed the old Duo GPG key. Unfortunately, the apt_repository
resource does not keep the key updated if it already exists, so it will need removed
and re-added with the new key that's good until 2020.