### PR TITLE
Regen Berksfile lock to pull in latest cookbook versions for chef 17 deprecations

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -6,24 +6,23 @@ provisioner:
   name: chef_zero
   channel: stable
   product_name: chef
-  product_version: 14.11.21
+  product_version: 15.15.1
   deprecations_as_errors: false
 
 platforms:
-  - name: ubuntu-18.04
-  - name: ubuntu-18.04-arm
+  - name: ubuntu-20.04
+  - name: ubuntu-20.04-arm
     driver:
       name: ec2
       instance_type: m6g.medium
       image_search:
         owner-id: "099720109477"
-        name: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-arm64-server-*
+        name: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-arm64-server-*
     provisioner:
-      product_version: 14.15.6
+      product_version: 15.15.1
     attributes:
       duosecurity:
         package_file: /tmp/kitchen/cache/duo-unix-1.11.4_arm64.deb
-  - name: ubuntu-20.04
 
 suites:
   - name: source

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,8 +2,5 @@ Metrics/LineLength:
   Severity: refactor
   Max: 120
 
-Style/TrailingCommaInLiteral:
-  Enabled: false
-
 Lint/ParenthesesAsGroupedExpression:
   Enabled: false

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,5 @@
-source "https://supermarket.chef.io/"
+# frozen_string_literal: true
+
+source 'https://supermarket.chef.io/'
 
 metadata

--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -4,14 +4,12 @@ DEPENDENCIES
     metadata: true
 
 GRAPH
-  ark (5.0.0)
-    seven_zip (>= 0.0.0)
-  duosecurity (2.1.1)
+  ark (6.0.3)
+    seven_zip (>= 3.1)
+  duosecurity (2.2.0)
     ark (>= 0.0.0)
     pam (>= 0.0.0)
     sshd (>= 0.0.0)
   pam (1.1.0)
-  seven_zip (3.1.2)
-    windows (>= 0.0.0)
-  sshd (3.0.0)
-  windows (7.0.0)
+  seven_zip (4.2.2)
+  sshd (3.1.1)

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 default['duosecurity']['install_type'] = 'source'
 default['duosecurity']['package_action'] = 'upgrade'
 default['duosecurity']['package_file'] = nil

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,15 +1,16 @@
+# frozen_string_literal: true
+
 name                'duosecurity'
 maintainer          'Matt Kulka'
 maintainer_email    'matt@lqx.net'
 license             'MIT'
 description         'Installs/Configures duosecurity two-factor system authentication on Ubuntu/Debian'
-long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version             '2.2.0'
+version             '3.0.0'
 
-source_url 'https://github.com/mattlqx/chef-duosecurity' if respond_to?(:source_url)
-issues_url 'https://github.com/mattlqx/chef-duosecurity/issues' if respond_to?(:issues_url)
+source_url 'https://github.com/mattlqx/chef-duosecurity'
+issues_url 'https://github.com/mattlqx/chef-duosecurity/issues'
 
-chef_version        '>= 15.3'
+chef_version '>= 15.3'
 
 supports   'debian'
 supports   'ubuntu'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,12 +4,12 @@ maintainer_email    'matt@lqx.net'
 license             'MIT'
 description         'Installs/Configures duosecurity two-factor system authentication on Ubuntu/Debian'
 long_description    IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version             '2.1.1'
+version             '2.2.0'
 
 source_url 'https://github.com/mattlqx/chef-duosecurity' if respond_to?(:source_url)
 issues_url 'https://github.com/mattlqx/chef-duosecurity/issues' if respond_to?(:issues_url)
 
-chef_version        '>= 14'
+chef_version        '>= 15.3'
 
 supports   'debian'
 supports   'ubuntu'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Required attributes
 integration_key     = node['duosecurity']['integration_key']
 secret_key          = node['duosecurity']['secret_key']
@@ -64,30 +66,30 @@ if use_pam == 'yes'
         'interface' => 'auth',
         'control_flag' => 'requisite',
         'name' => 'pam_unix.so',
-        'args' => 'nullok_secure',
+        'args' => 'nullok_secure'
       },
       'pam_duo' => {
         'interface' => 'auth',
         'control_flag' => '[success=1 default=ignore]',
-        'name' => '/lib64/security/pam_duo.so',
+        'name' => '/lib64/security/pam_duo.so'
       },
       'pam_deny' => {
         'interface' => 'auth',
         'control_flag' => 'requisite',
-        'name' => 'pam_deny.so',
+        'name' => 'pam_deny.so'
       },
       'pam_permit' => {
         'interface' => 'auth',
         'control_flag' => 'required',
-        'name' => 'pam_permit.so',
+        'name' => 'pam_permit.so'
       },
       'pam_cap' => {
         'interface' => 'auth',
         'control_flag' => 'optional',
-        'name' => 'pam_cap.so',
-      },
+        'name' => 'pam_cap.so'
+      }
     },
-    'includes' => [],
+    'includes' => []
   }
 
   node.default['pam_d']['services']['sshd'] = {
@@ -95,74 +97,74 @@ if use_pam == 'yes'
       'auth' => {
         'interface' => 'auth',
         'control_flag' => 'required',
-        'name' => '/lib64/security/pam_duo.so',
+        'name' => '/lib64/security/pam_duo.so'
       },
       'pam_nologin' => {
         'interface' => 'account',
         'control_flag' => 'required',
-        'name' => 'pam_nologin.so',
+        'name' => 'pam_nologin.so'
       },
       'pam_selinux close' => {
         'interface' => 'session',
         'control_flag' => '[success=ok ignore=ignore module_unknown=ignore default=bad]',
         'name' => 'pam_selinux.so',
-        'args' => 'close',
+        'args' => 'close'
       },
       'pam_loginuid' => {
         'interface' => 'session',
         'control_flag' => 'required',
-        'name' => 'pam_loginuid.so',
+        'name' => 'pam_loginuid.so'
       },
       'pam_keyinit' => {
         'interface' => 'session',
         'control_flag' => 'optional',
         'name' => 'pam_keyinit.so',
-        'args' => 'force revoke',
+        'args' => 'force revoke'
       },
       'include common-session' => {
         'interface' => '@include',
-        'name' => 'common-session',
+        'name' => 'common-session'
       },
       'pam_motd dynamic' => {
         'interface' => 'session',
         'control_flag' => 'optional',
         'name' => 'pam_motd.so',
-        'args' => 'motd=/run/motd.dynamic',
+        'args' => 'motd=/run/motd.dynamic'
       },
       'pam_motd' => {
         'interface' => 'session',
         'control_flag' => 'optional',
         'name' => 'pam_motd.so',
-        'args' => 'noupdate',
+        'args' => 'noupdate'
       },
       'pam_mail' => {
         'interface' => 'session',
         'control_flag' => 'optional',
         'name' => 'pam_mail.so',
-        'args' => 'standard noenv',
+        'args' => 'standard noenv'
       },
       'pam_limits' => {
         'interface' => 'session',
         'control_flag' => 'required',
-        'name' => 'pam_limits.so',
+        'name' => 'pam_limits.so'
       },
       'pam_env' => {
         'interface' => 'session',
         'control_flag' => 'required',
-        'name' => 'pam_env.so',
+        'name' => 'pam_env.so'
       },
       'pam_env locale' => {
         'interface' => 'session',
         'control_flag' => 'required',
         'name' => 'pam_env.so',
-        'args' => 'user_readenv=1 envfile=/etc/default/locale',
+        'args' => 'user_readenv=1 envfile=/etc/default/locale'
       },
       'pam_selinux open' => {
         'interface' => 'session',
         'control_flag' => '[success=ok ignore=ignore module_unknown=ignore default=bad]',
         'name' => 'pam_selinux.so',
-        'args' => 'open',
-      },
+        'args' => 'open'
+      }
     },
     'includes' => %w[
       common-account
@@ -175,7 +177,7 @@ if use_pam == 'yes'
   if first_factor == 'password'
     node.default['pam_d']['services']['sshd']['main']['auth'] = {
       'interface' => '@include',
-      'name' => 'common-auth',
+      'name' => 'common-auth'
     }
   end
 
@@ -186,18 +188,18 @@ if use_pam == 'yes'
           'interface' => 'auth',
           'control_flag' => 'required',
           'name' => 'pam_env.so',
-          'args' => 'readenv=1 user_readenv=0',
+          'args' => 'readenv=1 user_readenv=0'
         },
         'pam_env locale' => {
           'interface' => 'auth',
           'control_flag' => 'required',
           'name' => 'pam_env.so',
-          'args' => 'readenv=1 envfile=/etc/default/locale user_readenv=0',
+          'args' => 'readenv=1 envfile=/etc/default/locale user_readenv=0'
         },
         'pam_duo' => {
           'interface' => 'auth',
           'control_flag' => 'sufficient',
-          'name' => '/lib64/security/pam_duo.so',
+          'name' => '/lib64/security/pam_duo.so'
         }
       },
       'includes' => %w[

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mixlib/shellout'
 
 if node['duosecurity']['package_file']
@@ -10,9 +12,8 @@ elsif node['duosecurity']['use_duo_repo']
   codename = node['lsb']['codename']
 
   # Determine if key is expired
-  expired = Mixlib::ShellOut.new("apt-key list --list-keys 'Duo Security Package Signing' | grep expired") \
-                            .run_command \
-                            .exitstatus == 0
+  expired = shell_out("apt-key list --list-keys 'Duo Security Package Signing' | grep expired") \
+            .exitstatus.zero?
 
   execute 'remove expired duo repo key' do
     command 'apt-key del "30BF E024 2B19 592E B122  211D 1CC9 1FC6 15D3 2EFC"; apt-key del 15D32EFC'
@@ -25,7 +26,7 @@ elsif node['duosecurity']['use_duo_repo']
     components ['main']
     distribution codename
     key 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc'
-    action expired ? [:remove, :add] : :add
+    action expired ? %i[remove add] : :add
   end
 
   apt_update 'duo' do

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Install login_duo
 # https://www.duosecurity.com/docs/duounix#1.-set-up-login_duo
 


### PR DESCRIPTION
Resolves the following deprecations caused by old versions pulled in.

```
The  resource in the windows cookbook should declare unified_mode true at 5 locations:
- /var/chef/cache/cookbooks/windows/resources/certificate_binding.rb
- /var/chef/cache/cookbooks/windows/resources/dns.rb
- /var/chef/cache/cookbooks/windows/resources/http_acl.rb
- /var/chef/cache/cookbooks/windows/resources/schannel.rb
- /var/chef/cache/cookbooks/windows/resources/zipfile.rb
See Deprecation: Enabling Unified Mode (CHEF-33)  for further details.

The  resource in the seven_zip cookbook should declare unified_mode true at 2 locations:
- /var/chef/cache/cookbooks/seven_zip/resources/archive.rb
- /var/chef/cache/cookbooks/seven_zip/resources/tool.rb
See Deprecation: Enabling Unified Mode (CHEF-33)  for further details.

The  resource in the ark cookbook should declare unified_mode true at 1 location:
- /var/chef/cache/cookbooks/ark/resources/default.rb
See Deprecation: Enabling Unified Mode (CHEF-33)  for further details.
```