### PR TITLE
fix(package.rb): apt uri http to https

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ maintainer          'Matt Kulka'
 maintainer_email    'matt@lqx.net'
 license             'MIT'
 description         'Installs/Configures duosecurity two-factor system authentication on Ubuntu/Debian'
-version             '3.0.0'
+version             '3.0.1'
 
 source_url 'https://github.com/mattlqx/chef-duosecurity'
 issues_url 'https://github.com/mattlqx/chef-duosecurity/issues'

--- a/recipes/package.rb
+++ b/recipes/package.rb
@@ -21,8 +21,8 @@ elsif node['duosecurity']['use_duo_repo']
   end
 
   apt_repository 'duosecurity' do
-    uri "http://pkg.duosecurity.com/#{platform}"
-    arch 'amd64' if codename == 'bionic'
+    uri "https://pkg.duosecurity.com/#{platform}"
+    arch 'amd64' if %w(bionic focal).include? codename
     components ['main']
     distribution codename
     key 'https://duo.com/DUO-GPG-PUBLIC-KEY.asc'


### PR DESCRIPTION
- add focal

[duo prereqs](https://duo.com/docs/duounix#install-pam_duo-prerequisites) under ubuntu tab shows https
